### PR TITLE
composer.json: use HTTPS composer URL

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "repositories": [
         {
             "type": "composer",
-            "url": "http://wpackagist.org"
+            "url": "https://wpackagist.org"
         }
     ],
     "require": {


### PR DESCRIPTION
I got an error message with a pointer to https://getcomposer.org/doc/06-config.md#secure-http

After some careful reading I figured out that it should point to https://wpackagist.org instead of http://wpackagist.org
